### PR TITLE
create_function() deprecated in PHP 7.2

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -168,4 +168,8 @@ class WYLWidget extends WP_Widget {
     }
 } 
 
-add_action('widgets_init', create_function('', 'return register_widget("WYLWidget");'));
+function lyte_register_widget() {
+	register_widget('WYLWidget');
+}
+
+add_action('widgets_init', 'lyte_register_widget');


### PR DESCRIPTION
Since upgrading to PHP 7.2, I've been getting the following in my PHP error log:

    PHP Deprecated: Function create_function() is deprecated in .../wp-content/plugins/wp-youtube-lyte/widget.php on line 169

It does appear that create_function() is deprecated in PHP 7.2. The most elegant thing to do would, I think, be to use a proper anonymous function, but those aren’t supported before PHP 5.3, and WordPress tries to be backwards compatible to PHP 5.2.4.

I propose using a normal, named function for the callback.