### PR TITLE
Allow editing disclaimer text in code

### DIFF
--- a/wp-youtube-lyte.php
+++ b/wp-youtube-lyte.php
@@ -261,6 +261,7 @@ function lyte_parse( $the_content, $doExcerpt = false ) {
 
             // add disclaimer to lytelinks
             $disclaimer = wp_kses_data( get_option( 'lyte_disclaimer', '') );
+	    $disclaimer = apply_filters('lyte_disclaimer', $disclaimer);
             if ( !empty( $disclaimer ) ) {
                 $disclaimer = '<span class="lyte_disclaimer">' . $disclaimer . '</span>';
             }


### PR DESCRIPTION
The `lyte_disclaimer` is passed through `wp_kses_data` (very sensible) to remove any unwanted text/code.

However this means there is currently no way to add any text to the `lyte_disclaimer` block, without hacking the code. I propose adding a filter to allow themes/other functions to edit the text. 

Use case: in my case I want to add a small icon to the end of each `lyte_disclaimer` block. But images are removed by `wp_kses_data`