### PR TITLE
Add maxresdefault.jpg fallback

### DIFF
--- a/lyteCache.php
+++ b/lyteCache.php
@@ -180,11 +180,11 @@ function lyte_get_thumb( $thumbUrl ) {
         
         // fallback to hqdefault.jpg if maxresdefault.jpg is missing
         $info = curl_getinfo($curl);
-        if ($info['http_code'] === 404) {
-			curl_setopt( $curl, CURLOPT_URL, str_replace('maxresdefault.jpg', 'hqdefault.jpg', $thumbUrl ));
-			$str = curl_exec( $curl );
-			$err = curl_error( $curl );
-		}
+        if ($info['http_code'] === 404 && strpos($thumbUrl, 'maxresdefault.jpg') !== false) {
+		curl_setopt( $curl, CURLOPT_URL, str_replace('maxresdefault.jpg', 'hqdefault.jpg', $thumbUrl ));
+		$str = curl_exec( $curl );
+		$err = curl_error( $curl );
+	}
         
         curl_close( $curl );
         if ( ! $err && $str != '' ) {

--- a/lyteCache.php
+++ b/lyteCache.php
@@ -177,6 +177,15 @@ function lyte_get_thumb( $thumbUrl ) {
         curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 5 );
         $str = curl_exec( $curl );
         $err = curl_error( $curl );
+        
+        // fallback to hqdefault.jpg if maxresdefault.jpg is missing
+        $info = curl_getinfo($curl);
+        if ($info['http_code'] === 404) {
+			curl_setopt( $curl, CURLOPT_URL, str_replace('maxresdefault.jpg', 'hqdefault.jpg', $thumbUrl ));
+			$str = curl_exec( $curl );
+			$err = curl_error( $curl );
+		}
+        
         curl_close( $curl );
         if ( ! $err && $str != '' ) {
             return $str;


### PR DESCRIPTION
Dear author,

If HD is enabled, sometimes youtube will serve a gray image with dots as maxresdefault.jpg. Since the plugin doesn't check response codes, some videos may have broken thumbnails which is undesirable.

This fix checks curl status code and tries to fetch hqdefault.jpg if maxresdefault.jpg is missing.

Best regards,
Andrej
