### PR TITLE
Compatibility with bedrock-autoloader which loads plugins as must-use plugins

### DIFF
--- a/options.php
+++ b/options.php
@@ -343,7 +343,7 @@ function lyte_settings_page() {
             </div>
         </div>
     </div>
-    <div style="float:right;margin:50px 15px;"><a href="http://blog.futtta.be/2013/10/21/do-not-donate-to-me/" target="_blank"><img width="100px" height="85px" src="<?php echo plugins_url() . '/' . plugin_basename( dirname( __FILE__ ) ) . '/external/do_not_donate_smallest.png'; ?>" title="<?php _e( 'Do not donate for this plugin!', 'wp-youtube-lyte' ); ?>"></a></div>
+    <div style="float:right;margin:50px 15px;"><a href="http://blog.futtta.be/2013/10/21/do-not-donate-to-me/" target="_blank"><img width="100px" height="85px" src="<?php echo plugins_url( '/external/do_not_donate_smallest.png', __FILE__ ) ?>" title="<?php _e( 'Do not donate for this plugin!', 'wp-youtube-lyte' ); ?>"></a></div>
 </div>
 
 <script type="text/javascript">

--- a/widget.php
+++ b/widget.php
@@ -7,7 +7,7 @@ class WYLWidget extends WP_Widget {
     function widget($args, $instance) {
         extract( $args );
         global $wSize, $wyl_version, $wp_lyte_plugin_url, $lyteSettings;
-        $lyteSettings['path']= plugins_url() . "/" . dirname(plugin_basename(__FILE__)) . '/lyte/';
+        $lyteSettings['path']= plugins_url( '/lyte/', __FILE__ );
         $qsa = '';
 
         $WYLtitle = apply_filters( 'widget_title', $instance['WYLtitle'] );

--- a/wp-youtube-lyte.php
+++ b/wp-youtube-lyte.php
@@ -88,6 +88,7 @@ foreach ( $pSizeOrder[$pSizeFormat] as $sizeId ) {
 }
 
 /** get other options and push in array*/
+global $lyteSettings;
 $lyteSettings['sizeArray']                    = $sArray;
 $lyteSettings['selSize']                      = $selSize;
 $lyteSettings['links']                        = get_option( 'lyte_show_links' );
@@ -115,7 +116,7 @@ function lyte_parse( $the_content, $doExcerpt = false ) {
 
     /** main function to parse the content, searching and replacing httpv-links */
     global $lyteSettings, $toCache_index, $postID, $cachekey;
-    $lyteSettings['path'] = plugins_url() . '/' . dirname( plugin_basename( __FILE__ ) ) . '/lyte/';
+    $lyteSettings['path'] = plugins_url('/lyte/', __FILE__ );
     $urlArr               = parse_url( $lyteSettings['path'] );
     $origin               = $urlArr['scheme'] . '://' . $urlArr['host'];
 


### PR DESCRIPTION
Fixes 2 problems:
* Couple of times `plugins_url() . '/' . plugin_basename( dirname( __FILE__ ) ) . '<relative url here>'`  was used which resolved to `/plugins/wp-youtube-lyte/<relative url here>`. And that doesn't work when the plugin is loaded as `/mu-plugins/wp-youtube-lyte`.
* As workaround for issue roots/bedrock-autoloader#29, I explicitly made `$lyteSettings` declared as `global`.