### PR TITLE
Replace solo URLs only when at the beginning of a line

### DIFF
--- a/wp-youtube-lyte.php
+++ b/wp-youtube-lyte.php
@@ -801,7 +801,7 @@ function lyte_prepare( $the_content ) {
                 foreach ( $vids as $vid ) {
                     if ( is_array( $vid ) && array_key_exists( 1, $vid ) && false === strpos( trim( $vid[0] ), ' ' ) ) {
                         $vid_repla   = str_replace( $vid[1], $prep_repla['replace'], $vid[0] );
-                        $the_content = str_replace( $vid[0], $vid_repla, $the_content );
+                        $the_content = preg_replace( '/^' . preg_quote($vid[0], '/') . '/m', $vid_repla, $the_content );
                     }
                 }
             }


### PR DESCRIPTION
Ensures replaced URLs are only ones at the beginning of a lie.

Fixes https://github.com/futtta/wp-youtube-lyte/issues/42

The previous `str_replace()` would replace all occurrences of a YouTube URL, even if it was embedded in a paragraph, e.g.:

```html
This is rendered properly:

https://www.youtube.com/watch?v=dQw4w9WgXcQ

<em>This same URL <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">is rendered improperly</a>.</em>
```