### PR TITLE
Fixed issue with loading textdomain too early

### DIFF
--- a/player_sizes.inc.php
+++ b/player_sizes.inc.php
@@ -1,8 +1,5 @@
 <?php
 
-$plugin_dir = basename( dirname( __FILE__ ) ) . '/languages';
-load_plugin_textdomain( 'wp-youtube-lyte', false, $plugin_dir );
-
 $pDefault=2;
 
 $pSize[8]['a'] = true;

--- a/wp-youtube-lyte.php
+++ b/wp-youtube-lyte.php
@@ -61,44 +61,46 @@ if (!$debug) {
     lyte_rm_cache();
 }
 
-/** get paths, language and includes */
-$plugin_dir = basename( dirname( __FILE__ ) ) . '/languages';
-load_plugin_textdomain( 'wp-youtube-lyte', null, $plugin_dir );
-require_once( dirname( __FILE__ ) . '/player_sizes.inc.php' );
+/** get includes */
 require_once( dirname( __FILE__ ) . '/widget.php' );
 
-/** get default embed size and build array to change size later if requested */
-$oSize = (int) get_option( 'lyte_size' );
-if ( (is_bool( $oSize ) ) || ( $pSize[$oSize]['a'] === false ) ) {
-    $sel = (int) $pDefault;
-} else {
-    $sel=$oSize;
+function init_settings() {
+	global $pDefault, $pSize, $pSizeOrder, $lyteSettings, $wyl_version, $wyl_file, $wyl_file_lazyload;
+
+	require_once( dirname( __FILE__ ) . '/player_sizes.inc.php' );
+
+	/** get default embed size and build array to change size later if requested */
+	$oSize = (int) get_option( 'lyte_size' );
+	if ( (is_bool( $oSize ) ) || ( $pSize[$oSize]['a'] === false ) ) {
+		$sel = (int) $pDefault;
+	} else {
+		$sel=$oSize;
+	}
+
+	$pSizeFormat = $pSize[$sel]['f'];
+	$j           = 0;
+
+	foreach ( $pSizeOrder[$pSizeFormat] as $sizeId ) {
+		$sArray[$j]['w'] = (int) $pSize[$sizeId]['w'];
+		$sArray[$j]['h'] = (int) $pSize[$sizeId]['h'];
+		if ( $sizeId === $sel ) {
+			$selSize=$j;
+		}
+		$j++;
+	}
+
+	/** get other options and push in array*/
+	$lyteSettings['sizeArray']                    = $sArray;
+	$lyteSettings['selSize']                      = $selSize;
+	$lyteSettings['links']                        = get_option( 'lyte_show_links' );
+	$lyteSettings['file']                         = $wyl_file . '?wyl_version=' . $wyl_version;
+	$lyteSettings['file_lazyload']                = $wyl_file_lazyload . '?wyl_version=' . $wyl_version;
+	$lyteSettings['ratioClass']                   = ( $pSizeFormat === '43' ) ? ' fourthree' : '';
+	$lyteSettings['pos']                          = ( get_option( 'lyte_position', '0' ) === '1' ) ? 'margin:5px auto;' : 'margin:5px;';
+	$lyteSettings['microdata']                    = get_option( 'lyte_microdata', '1' );
+	$lyteSettings['hidef']                        = get_option( 'lyte_hidef', 0 );
+	$lyteSettings['scheme']                       = ( is_ssl() ) ? 'https' : 'http';
 }
-
-$pSizeFormat = $pSize[$sel]['f'];
-$j           = 0;
-
-foreach ( $pSizeOrder[$pSizeFormat] as $sizeId ) {
-    $sArray[$j]['w'] = (int) $pSize[$sizeId]['w'];
-    $sArray[$j]['h'] = (int) $pSize[$sizeId]['h'];
-    if ( $sizeId === $sel ) {
-        $selSize=$j;
-    }
-    $j++;
-}
-
-/** get other options and push in array*/
-global $lyteSettings;
-$lyteSettings['sizeArray']                    = $sArray;
-$lyteSettings['selSize']                      = $selSize;
-$lyteSettings['links']                        = get_option( 'lyte_show_links' );
-$lyteSettings['file']                         = $wyl_file . '?wyl_version=' . $wyl_version;
-$lyteSettings['file_lazyload']                = $wyl_file_lazyload . '?wyl_version=' . $wyl_version;
-$lyteSettings['ratioClass']                   = ( $pSizeFormat === '43' ) ? ' fourthree' : '';
-$lyteSettings['pos']                          = ( get_option( 'lyte_position', '0' ) === '1' ) ? 'margin:5px auto;' : 'margin:5px;';
-$lyteSettings['microdata']                    = get_option( 'lyte_microdata', '1' );
-$lyteSettings['hidef']                        = get_option( 'lyte_hidef', 0 );
-$lyteSettings['scheme']                       = ( is_ssl() ) ? 'https' : 'http';
 
 /** API: filter hook to alter $lyteSettings */
 function lyte_settings_enforcer() {
@@ -846,18 +848,25 @@ function lytecache_doublecheck_activator() {
     }
 }
 
+function lyte_plugin_init() {
+	$plugin_dir = basename( dirname( __FILE__ ) ) . '/languages';
+	load_plugin_textdomain( 'wp-youtube-lyte', null, $plugin_dir );
+	init_settings();
+	lytecache_doublecheck_activator();
+}
+
 /** hooking it all up to wordpress */
 if ( is_admin() ) {
     require_once(dirname(__FILE__).'/options.php');
     add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'lyte_add_action_link' );
-    add_action( 'admin_init', 'lytecache_doublecheck_activator' );
+    add_action( 'admin_init', 'lyte_plugin_init' );
 } else {
     add_filter( 'the_content', 'lyte_prepare', 4 );
     add_filter( 'the_content', 'lyte_parse', 10 );
     add_shortcode( 'lyte', 'shortcode_lyte' );
     remove_filter( 'get_the_excerpt', 'wp_trim_excerpt' );
     add_filter( 'get_the_excerpt', 'lyte_trim_excerpt', 10, 2 );
-    add_action( 'init', 'lytecache_doublecheck_activator' );
+    add_action( 'init', 'lyte_plugin_init' );
 
     /** API: action hook to allow extra actions or filters to be added */
     do_action('lyte_actionsfilters');


### PR DESCRIPTION
Instead of calling load_plugin_textdomain() when the php file is loaded, wait for the WP init (or admin_init) hook. Data in player_sizes.inc.php also uses localisation, so don't load that or related global settings until we load the textdomain.