### PR TITLE
Fix compatibility with bedrock-autoloader

### DIFF
--- a/wp-youtube-lyte.php
+++ b/wp-youtube-lyte.php
@@ -49,7 +49,7 @@ if ($lyte_db_version !== $lyte_version) {
 }
 
 /** are we in debug-mode */
-
+global $wyl_version, $wyl_file, $wyl_file_lazyload;
 if (!$debug) {
     $wyl_version       = $lyte_version;
     $wyl_file          = 'lyte-min.js';


### PR DESCRIPTION
For some reason the fix in PR #40 got broken again.
I fixed it once again by declaring the bootstrap variables explicitly as global.